### PR TITLE
fixed Debian (and Ubuntu) installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ make run
 ```
 Debian
 ```shell
-git clone https://github.com/RMPR/atbswp.git && cd atbswp
 sudo apt install git python3-dev python3-tk python3-setuptools python3-wheel python3-pip python3-wxgtk4.0
+git clone https://github.com/RMPR/atbswp.git && cd atbswp
 python3 -m pip install -r requirements-dev.txt
 python3 atbswp/atbswp.py
 ```

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ make run
 Debian
 ```shell
 git clone https://github.com/RMPR/atbswp.git && cd atbswp
-sudo apt install python3-wxgtk4.0
-pip install -r requirements.txt
-python atbswp/atbswp.py
+sudo apt install git python3-dev python3-tk python3-setuptools python3-wheel python3-pip python3-wxgtk4.0
+python3 -m pip install -r requirements-dev.txt
+python3 atbswp/atbswp.py
 ```
 Windows
 ```shell


### PR DESCRIPTION
Added extra dependencies without which this doesn't run, use pip with python3 instead of python2 (on Debian and Ubuntu, python is python2), use python3 for the run command, and replace non-existing requirements.txt with requirements-dev.txt.