### PR TITLE
string-literal-fix - change en to 'en' to prevent error

### DIFF
--- a/atbswp/settings.py
+++ b/atbswp/settings.py
@@ -51,4 +51,4 @@ except OSError:
                          'Recording Hotkey': 348,
                          'Playback Hotkey': 349,
                          'Always On Top': True,
-                         'Language': en}
+                         'Language': 'en'}


### PR DESCRIPTION
Not sure if there's an environment where the original literal en would work, but I was not able to start the program without this being turned into a string. Feel free to change as needed if it's a valid change :)