### PR TITLE
Prevent atbswp from crashing after updating from v0.1

### DIFF
--- a/atbswp/gui.py
+++ b/atbswp/gui.py
@@ -185,9 +185,8 @@ class MainDialog(wx.Dialog, wx.MiniFrame):
             lang = settings.CONFIG.get('DEFAULT', 'Language')
             locale = open(os.path.join(self.path, "lang", lang)).read().splitlines()
         except:
-            return
-        if locale == []:
-            return
+            return self.app_text + self.settings_text
+
         return locale
 
     def __add_bindings(self):


### PR DESCRIPTION
If the user is updating from the previous version
(without language support) then the setting about the
language doesn't exist and cause the app to crash on
startup, this commit fix this problem by hardcoding the
english language so that if it doesn't exist for one
reason or another it uses english by default.