### PR TITLE
Fix issue #28

### DIFF
--- a/atbswp/gui.py
+++ b/atbswp/gui.py
@@ -260,8 +260,7 @@ class MainDialog(wx.Dialog, wx.MiniFrame):
                 btnEvent = wx.CommandEvent(wx.wxEVT_TOGGLEBUTTON)
                 btnEvent.EventObject = self.play_button
                 control.PlayCtrl().action(btnEvent)
-        else:
-            event.Skip()
+        event.Skip()
 
     def on_exit_app(self, event):
         """Clean exit saving the settings."""


### PR DESCRIPTION
This commit is an attempt to fix an inconsistent behaviour with keybaord
shortcuts which will randomly stop working even when atbswp has the
focus.