### PR TITLE
French translations updated

### DIFF
--- a/atbswp/lang/fr
+++ b/atbswp/lang/fr
@@ -5,12 +5,12 @@ Jouer une capture
 Transformer en exécutable
 Paramètres
 Aide
-Vitesse: Rapide
-Playback Infini
-Nombre de Repétitions
-Touche d'Enregistrement
-Touche de Playback
-Toujours Au-dessus
+Vitesse : rapide
+Playback infini
+Nombre de répétitions
+Touche d'enregistrement
+Touche de playback
+Toujours au-dessus
 Langue
 À propos
-Minuterie d'Enregistrement
+Minuterie d'enregistrement


### PR DESCRIPTION
This pull request:

- fixes a typo (missing accent in "Repétitions"),
- makes consistent the capitalization (e.g. "Sauvegarder une capture" but "Touche d'Enregistrement").