### PR TITLE
Fix time.sleep without movement

### DIFF
--- a/atbswp/control.py
+++ b/atbswp/control.py
@@ -204,13 +204,6 @@ class RecordCtrl:
         """Triggered by a mouse move."""
         if not self.recording:
             return False
-        
-        def isinteger(s):
-            try:
-                int(s)
-                return True
-            except:
-                return False
 
         if abs(x - self._lastx) < self.mouse_sensibility \
            and abs(y - self._lasty) < self.mouse_sensibility:


### PR DESCRIPTION
I had the problem that there was a time.sleep in the output script, even though the mouse was not moved.  I moved the check, if there is enough mouse movement to the on_move function. Like this it should be cleaner (no need to seperate the parameters string) and there is only a sleep if the mouse is really moving :)