### PR TITLE
Information about running on sessions running Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,15 @@ enable Xorg.
 ```
 sudo sed 's/#WaylandEnable=false/WaylandEnable=false/' /etc/gdm/custom.conf -i # on Gnome
 ```
-[on Fedora](https://docs.fedoraproject.org/en-US/quick-docs/configuring-xorg-as-default-gnome-session/)
+[On Fedora](https://docs.fedoraproject.org/en-US/quick-docs/configuring-xorg-as-default-gnome-session/).
+
+
+Alternatively running with `GDK_BACKEND=x11` may help.
+
+```
+GDK_BACKEND=x11 ./atbswpv0.3.0-linux
+```
+It could be used to create appropriate ".desktop" entry.
 
 # Join us
 To keep up with the latest news about atbswp you can reach us on this [telegram channel](https://t.me/atbswp) we will


### PR DESCRIPTION
Hi.

On Ubuntu 22.04 I managed to run the application on Wayland session using `GDK_BACKEND=x11`. I've found this solution there: https://github.com/Ultimaker/Cura/issues/12776 , so the issue and solution may be quite common I believe.

Thank You for this application by the way!